### PR TITLE
Support upcoming leaflet 1.0.0 release

### DIFF
--- a/src/wunderground.layer.js
+++ b/src/wunderground.layer.js
@@ -1,7 +1,7 @@
 ﻿/**
  * Layer for current radar and satellite data from Weather Underground
  */
-L.Wunderground = L.Class.extend({
+L.Wunderground = (L.Layer?L.Layer:L.Class).extend({
 
 	includes: L.Mixin.Events,
 
@@ -23,7 +23,7 @@ L.Wunderground = L.Class.extend({
 	onAdd: function (map) {
 		this._map = map;
 
-		this.update = L.Util.limitExecByInterval(this.update, this.options.updateInterval, this);
+		this.update = (L.Util.throttle?L.Util.throttle:L.Util.limitExecByInterval)(this.update, this.options.updateInterval, this);
 
 		this._map.on('moveend', this.update, this);
 


### PR DESCRIPTION
`limitExecByInterval` has been replaced with by `throttle` (https://github.com/Leaflet/Leaflet/commit/47783821f7f54dba810288dfe716e5d655cca351)

In 0.8, all layers must inherit from `L.Layer` class
